### PR TITLE
Renamed test.py to testfmt.py  + k_means_fast() now creates a new ImageDetails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "wyvern"
-version = "0.0.9"
+version = "0.1.0"
 dependencies = [
  "clap",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wyvern"
-version = "0.0.9"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scripts/testfmt.py
+++ b/scripts/testfmt.py
@@ -74,6 +74,7 @@ def rustfmt() -> bool:
         err_msg(excp, cmd)
 
 if __name__ == "__main__":
+    teardown() # preflight teardown to be safe
     rustfmt()
     execute_tests()
     teardown()

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -84,5 +84,9 @@ pub fn k_means_fast(image_details: &mut ImageDetails) -> Result<bool, Box<dyn Er
         start_x += 128;
         end_x += 128;
     }
-    Ok(image_details.save_image(output_buf, &"common_colors")?)
+
+    // create a new ImageDetails object to create the output image
+    let mut output_image: ImageDetails =
+        ImageDetails::new_image(&image_details.filepath.display().to_string());
+    Ok(output_image.save_image(output_buf, &"common_colors")?)
 }


### PR DESCRIPTION
…when saving the output buffer instead of using the input ImageDetails, thus avoiding overwrite of input image details